### PR TITLE
fix: error serialization when using common-errors

### DIFF
--- a/src/utils/serialization.js
+++ b/src/utils/serialization.js
@@ -41,6 +41,7 @@ function serializeError(error) {
 
   serialized.data = Object
     .getOwnPropertyNames(error)
+    .filter((prop) => typeof error[prop] !== 'function')
     .map(serializeOwnProperties, error);
 
   return serialized;


### PR DESCRIPTION
Fixes errors:
```
TypeError: Cannot read property 'name' of undefined
    at Object.errSerializer [as err] (/src/node_modules/pino/node_modules/pino-std-serializers/lib/err.js:45:31)
    at Pino.asJson (/src/node_modules/pino/lib/tools.js:122:50)
    at Pino.write (/src/node_modules/pino/lib/proto.js:163:28)
    at Pino.LOG [as error] (/src/node_modules/pino/lib/tools.js:55:21)
```